### PR TITLE
Use latest aeminer and update locks

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,7 @@
 
 {deps, [{jsx, {git, "https://github.com/talentdeficit/jsx.git", {tag, "2.9.0"}}},
         {base58, {git, "https://github.com/aeternity/erl-base58.git", {ref,"60a3356"}}},
-        {aeminer, {git, "https://github.com/aeternity/aeminer.git", {ref, "0a82f0f"}}}
+        {aeminer, {git, "https://github.com/aeternity/aeminer.git", {ref, "ccdf1ef"}}}
        ]}.
 
 {dialyzer, [{warnings, [unknown]},

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,7 +1,7 @@
 {"1.1.0",
 [{<<"aecuckoo">>,
   {git,"https://github.com/aeternity/aecuckoo.git",
-      {ref,"a1bff574dd0a965d3f9f2e23f980bbead8b4638d"}},
+      {ref,"695fbbc8245dbadab7edf4e4a119f094a5a400d3"}},
   1},
  {<<"aecuckooprebuilt">>,
   {aecuckooprebuilt_app_with_priv_from_git,
@@ -18,7 +18,7 @@
   0},
  {<<"enacl">>,
   {git,"https://github.com/aeternity/enacl.git",
-      {ref,"26180f42c0b3a450905d2efd8bc7fd5fd9cece75"}},
+      {ref,"67fceef42c0d055570f2e67b571f8d1f8de2f204"}},
   1},
  {<<"goldrush">>,{pkg,<<"goldrush">>,<<"0.1.9">>},2},
  {<<"jsx">>,
@@ -27,7 +27,7 @@
   0},
  {<<"lager">>,
   {git,"https://github.com/erlang-lager/lager.git",
-      {ref,"69b4ada2341b8ab2cf5c8e464ac936e5e4a9f62b"}},
+      {ref,"fae53399253da622afde3bf5fb5ff124b7d887fa"}},
   1}]}.
 [
 {pkg_hash,[


### PR DESCRIPTION
All needed to get aeternity running on an m1 Mac

This PR was sponsored by the ACF